### PR TITLE
Adding params for PE

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,12 +41,12 @@
 #
 #
 class graphite_reporter (
-  $graphite_host  = '127.0.0.1',
-  $graphite_port  = 2003,
-  $config_file    = '/etc/puppet/graphite.yaml',
-  $config_owner   = 'puppet',
-  $config_group   = 'puppet',
-){
+  $graphite_host  = $graphite_reporter::params::graphite_host,
+  $graphite_port  = $graphite_reporter::params::graphite_port,
+  $config_file    = $graphite_reporter::params::config_file,
+  $config_owner   = $graphite_reporter::params::config_owner,
+  $config_group   = $graphite_reporter::params::config_group,
+) inherits graphite_reporter::params {
 
   file { $config_file:
     ensure  => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,14 @@
 #   String.  Path to write the config file to
 #   Default: /etc/puppet/graphite.yaml
 #
+# [*config_owner*]
+#   String.  Owner of the config file. Should be pe_puppet for Puppet Enterprise.
+#   Default: puppet
+#
+# [*config_group*]
+#   String.  The config file's group. Should be pe_puppet for Puppet Enterprise.
+#   Default: puppet
+#
 #
 # === Examples
 #
@@ -36,12 +44,14 @@ class graphite_reporter (
   $graphite_host  = '127.0.0.1',
   $graphite_port  = 2003,
   $config_file    = '/etc/puppet/graphite.yaml',
+  $config_owner   = 'puppet',
+  $config_group   = 'puppet',
 ){
 
   file { $config_file:
     ensure  => file,
-    owner   => 'puppet',
-    group   => 'puppet',
+    owner   => $config_owner,
+    group   => $config_group,
     mode    => '0444',
     content => template('graphite_reporter/graphite.yaml.erb'),
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,14 @@
+class graphite_reporter::params {
+  $graphite_host = '127.0.0.1'
+  $graphite_port = 2003
+
+  if $::is_pe {
+    $config_file  = '/etc/puppetlabs/puppet/graphite.yaml'
+    $config_owner = 'pe_puppet'
+    $config_group = 'pe_puppet'
+  } else {
+    $config_file  = '/etc/puppet/graphite.yaml'
+    $config_owner = 'puppet'
+    $config_group = 'puppet'
+  }
+}

--- a/spec/classes/graphite_reporter_init_spec.rb
+++ b/spec/classes/graphite_reporter_init_spec.rb
@@ -1,9 +1,30 @@
 require 'spec_helper'
- 
-describe 'graphite_reporter', :type => :class do
 
+describe 'graphite_reporter', :type => :class do
   it { should create_class('graphite_reporter') }
-  it { should contain_file('/etc/puppet/graphite.yaml') }
+
+  context 'when being applied on pe' do
+    let (:facts) {{ :is_pe => true }}
+    it do
+      should contain_file('/etc/puppetlabs/puppet/graphite.yaml').with({
+        'owner' => 'pe_puppet',
+        'group' => 'pe_puppet',
+        'mode'  => '0444',
+      })
+    end
+  end
+
+  context 'when being applied on poss' do
+    let (:facts) {{ :is_pe => false }}
+    it do
+      should contain_file('/etc/puppet/graphite.yaml').with({
+        'owner' => 'puppet',
+        'group' => 'puppet',
+        'mode'  => '0444',
+      })
+    end
+  end
+
 
 end
 


### PR DESCRIPTION
The config file owner should be set to puppet on POSS and pe_puppet on Puppet Enterprise.  This fix allows users to pass group and owner as class params that default to the open source values.