### PR TITLE
Bugfix: $is_pe fact can be a string. 

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,4 +1,8 @@
 fixtures:
+  forge_modules:
+    stdlib:
+      repo: "puppetlabs/stdlib"
+      ref: "4.1.0"  
   symlinks:
     graphite_reporter: "#{source_dir}"
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Requirements
 
 * `Puppet`
 * A [Graphite](http://graphite.wikidot.com/) server
+* puppetlabs/stdlib (>= 4.0.0) module
 
 Installation & Usage
 --------------------

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class graphite_reporter::params {
   $graphite_suffix = 'puppet'
   $graphite_reverse_hostname = true
 
-  if $::is_pe {
+  if str2bool($::is_pe) {
     $config_file  = '/etc/puppetlabs/puppet/graphite.yaml'
     $config_owner = 'pe_puppet'
     $config_group = 'pe_puppet'


### PR DESCRIPTION
Using stdlib to convert string/boolean fact into boolean.

Split off the issue frrom previous PR https://github.com/evenup/evenup-graphite_reporter/pull/16
