### PR TITLE
Add support for flattening the hostname component of metrics.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,21 @@
 #   String.  The config file's group. Should be pe_puppet for Puppet Enterprise.
 #   Default: puppet
 #
+# [*graphite_prefix*]
+#   String.  Prefix to use for graphite metrics.
+#   Default: undef
+#
+# [*graphite_suffix*]
+#   String.  Suffix to use for graphite metrics.
+#   Default: puppet
+#
+# [*graphite_reverse_hostname*]
+#   Bool.  Reverse the components of the fqdn in the graphite metrics.
+#   Default: true
+#
+# [*graphite_flatten_hostname*]
+#   Bool. Replace all dot ('.') characters in the fqdn with underscores ('_').
+#   Default: false
 #
 # === Examples
 #
@@ -41,15 +56,15 @@
 #
 #
 class graphite_reporter (
-  $graphite_host  = $graphite_reporter::params::graphite_host,
-  $graphite_port  = $graphite_reporter::params::graphite_port,
-  $config_file    = $graphite_reporter::params::config_file,
-  $config_owner   = $graphite_reporter::params::config_owner,
-  $config_group   = $graphite_reporter::params::config_group,
-
+  $graphite_host             = $graphite_reporter::params::graphite_host,
+  $graphite_port             = $graphite_reporter::params::graphite_port,
+  $config_file               = $graphite_reporter::params::config_file,
+  $config_owner              = $graphite_reporter::params::config_owner,
+  $config_group              = $graphite_reporter::params::config_group,
   $graphite_prefix           = $graphite_reporter::params::graphite_prefix,
   $graphite_suffix           = $graphite_reporter::params::graphite_suffix,
   $graphite_reverse_hostname = $graphite_reporter::params::graphite_reverse_hostname,
+  $graphite_flatten_hostname = $graphite_reporter::params::graphite_flatten_hostname,
 ) inherits graphite_reporter::params {
 
   file { $config_file:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class graphite_reporter::params {
   $graphite_prefix = undef
   $graphite_suffix = 'puppet'
   $graphite_reverse_hostname = true
+  $graphite_flatten_hostname = false
 
   if str2bool($::is_pe) {
     $config_file  = '/etc/puppetlabs/puppet/graphite.yaml'

--- a/templates/graphite.yaml.erb
+++ b/templates/graphite.yaml.erb
@@ -4,3 +4,4 @@
 :graphite_prefix: <%= scope.lookupvar('graphite_prefix') %>
 :graphite_suffix: <%= scope.lookupvar('graphite_suffix') %>
 :graphite_reverse_hostname: <%= scope.lookupvar('graphite_reverse_hostname') %> 
+:graphite_flatten_hostname: <%= scope.lookupvar('graphite_flatten_hostname') %> 


### PR DESCRIPTION
Add support for a new parameter `graphite_flatten_hostname` that converts the hostname into one single graphite metric component.

In our case we do not use the components of the host fqdn as part of the
metric tree. Instead, the fqdn is a single component with dots replaced
by underscores. e.g. foo.example.com becomes foo_example_com.

This commit adds support for this but leaves it turned off by default.
It also adds the missing parameter docs to the class header.
