### PR TITLE
Do *not* use the titleized name of the metric because it can contain spaces

### DIFF
--- a/lib/puppet/reports/graphite.rb
+++ b/lib/puppet/reports/graphite.rb
@@ -48,7 +48,7 @@ Puppet::Reports.register_report(:graphite) do
     epochtime = Time.now.utc.to_i
     self.metrics.each { |metric,data|
       data.values.each { |val| 
-        name = "#{prefix}.#{val[1]}.#{metric}"
+        name = "#{prefix}.#{val[0]}.#{metric}"
         value = val[2]
 
         send_metric "#{name} #{value} #{epochtime}"


### PR DESCRIPTION
The titleized name of a metric is its name with underscores replaced
with spaces and the first word capitalized. This causes metrics for
resources with underscores in the name not to work because graphite
doesn't allow spaces in metric names.

This commit changes the report processor to use the standard name instead.
