### PR TITLE
Add possibility to remove graphite_prefix and graphite_suffix from config file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,20 @@
 #   String.  The config file's group. Should be pe_puppet for Puppet Enterprise.
 #   Default: puppet
 #
+# [*graphite_prefix*]
+#   String. Prefix added to the metric name before hostname.
+#   When set to undef of 'absent' it's not added to config file.
+#   Default: undef
+#
+# [*graphite_suffix*]
+#   String. Suffix added to the metric name after hostname.
+#   When set to undef of 'absent' it's not added to config file.
+#   Default: 'puppet'
+#
+# [*graphite_reverse_hostname*]
+#   Boolean. When true the hostname is reversed in metric name.
+#   Default: true
+#
 #
 # === Examples
 #

--- a/templates/graphite.yaml.erb
+++ b/templates/graphite.yaml.erb
@@ -1,6 +1,10 @@
 ---
 :graphite_server: <%= scope.lookupvar('graphite_host') %>
 :graphite_port: <%= scope.lookupvar('graphite_port') %>
+<% if ![nil, :undef, 'absent'].include?(scope.lookupvar('graphite_prefix')) -%>
 :graphite_prefix: <%= scope.lookupvar('graphite_prefix') %>
+<% end -%>
+<% if ![nil, :undef, 'absent'].include?(scope.lookupvar('graphite_suffix')) -%>
 :graphite_suffix: <%= scope.lookupvar('graphite_suffix') %>
+<% end -%>
 :graphite_reverse_hostname: <%= scope.lookupvar('graphite_reverse_hostname') %> 


### PR DESCRIPTION
I need a possibility to remove options `graphite_prefix` and `graphite_suffix` from config file (and from graphite metric names).

With current version from master when I didn't set the `graphite_prefix` param, I've got this in config file:
```
:graphite_prefix: undef
:graphite_suffix: puppet
:graphite_reverse_hostname: true
```
and also got undef in graphite metric names.

----
After this change:
* prefix is not added by default
* both prefix and suffix can be removed by setting them to `'absent'`:
```
class { '::graphite_reporter':
  graphite_prefix => 'absent',
  graphite_suffix => 'absent',
}
```
