### PR TITLE
Switch from deprecated %{linenumber} to %{line} in log format

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ exclude_paths = [
 PuppetLint.configuration.relative = true
 PuppetLint.configuration.fail_on_warnings
 PuppetLint.configuration.ignore_paths = exclude_paths
-PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
+PuppetLint.configuration.log_format = "%{path}:%{line}:%{check}:%{KIND}:%{message}"
 PuppetLint.configuration.send('relative')
 PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')


### PR DESCRIPTION
%{linenumber} was deprecated since puppet 1.0, and support was removed in puppet 1.8